### PR TITLE
Persist history across sessions

### DIFF
--- a/clai.sh
+++ b/clai.sh
@@ -456,6 +456,7 @@ EXPOSE_CURRENT_DIR=$(cfg_val "expose_current_dir")
 
 # Extract maximum history message count from configuration
 MAX_HISTORY_COUNT=$(cfg_val "max_history")
+MAX_HISTORY_COUNT=$(jq -Rn --arg value "$MAX_HISTORY_COUNT" '$value | tonumber? // 0')
 
 load_history
 

--- a/test/smoke.bats
+++ b/test/smoke.bats
@@ -297,3 +297,41 @@ EOF
   [ "$status" -eq 0 ]
   [ "$(jq 'length' "$TEST_HOME/.local/state/clai/history_com.json")" -eq 2 ]
 }
+
+@test "invalid max_history falls back safely during persistence" {
+  write_config <<'EOF'
+key=test-key
+hi_contrast=false
+expose_current_dir=true
+max_history=2 # invalid inline comment
+api=https://example.invalid/v1/chat/completions
+model=gpt-4o-mini
+json_mode=false
+temp=0.1
+tokens=500
+exec_query=
+question_query=
+error_query=
+EOF
+
+  mkdir -p "$TEST_HOME/.local/state/clai"
+  cat > "$TEST_HOME/.local/state/clai/history_com.json" <<'EOF'
+[{"role":"user","content":"one"},{"role":"assistant","content":"{\"info\":\"two\"}"}]
+EOF
+
+  make_success_curl
+
+  run env \
+    HOME="$TEST_HOME" \
+    TMPDIR="$TEST_HOME/tmp" \
+    PATH="$TEST_HOME/fakebin:$PATH" \
+    USER="bats" \
+    LANG="C" \
+    LC_TIME="C" \
+    TEST_HOME="$TEST_HOME" \
+    bash ./clai.sh "what is the current time?"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"syntax error"* ]]
+  [ "$(jq 'length' "$TEST_HOME/.local/state/clai/history_com.json")" -eq 1 ]
+}


### PR DESCRIPTION
## Summary
- persist CLAI history for both interactive mode and command mode through shared load/save helpers
- save history on interactive exit instead of bypassing persistence
- apply max-history trimming in the shared save path
- add Bats coverage for interactive persistence, history reload, and trimming

## Verification
- make check

## Follow-up
- #12 covers the persistence architecture improvements that are intentionally out of scope here.

Fixes #4
Refs #11
Refs #12